### PR TITLE
copy permission bits when single file defined in CodeUri

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -209,7 +209,7 @@ def mktempfile():
 def copy_to_temp_dir(filepath):
     tmp_dir = tempfile.mkdtemp()
     dst = os.path.join(tmp_dir, os.path.basename(filepath))
-    shutil.copyfile(filepath, dst)
+    shutil.copy(filepath, dst)
     return tmp_dir
 
 


### PR DESCRIPTION
`CodeUri:` is set to a file (eg. golang compiled file), the file permissions are not copied across when packaged using `aws cloudformation package`  and `aws cloudformation deploy`. The packaged file has these permission `-rw-r--r--`.  I get the following error when test the lambda function. 
`{ "errorMessage": "fork/exec /var/task/main: permission denied", "errorType": "PathError" }`

`shutil.copyfile` doesn't copy the file permission bits, however `shutil.copy` copies the permission bits. The original file permission is `rwxr-xr-x`.